### PR TITLE
Resume playback after sliding

### DIFF
--- a/app/assets/javascripts/showterm.js
+++ b/app/assets/javascripts/showterm.js
@@ -77,7 +77,7 @@ $(function () {
         }
     });
 
-    $('.controls > a[url^=#]').click(function () {
+    $('.controls > a[href^=#]').click(function () {
         window.location.hash = this.href.split('#')[1];
         if (paused) {
             paused = false;


### PR DESCRIPTION
This PR fix the issue #2 that prevent the user to resume the playback after using the slider or when he's being send directly to a specific point of the timeline.
