### PR TITLE
Add a Docker build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ruby:2.1.2
+
+# Add an unprivileged user
+RUN adduser --disabled-login --system --gecos 'ShowTerm' showterm
+
+# Install dependencies
+RUN apt-get update \
+  && apt-get -y install nodejs \
+  && apt-get clean
+
+RUN mkdir /srv/showterm \
+  && chown -R showterm /srv/showterm
+
+WORKDIR /srv/showterm
+ADD Gemfile /srv/showterm/Gemfile
+ADD Gemfile.lock /srv/showterm/Gemfile.lock
+
+RUN bundle install --path=$(pwd)
+
+# Insert shorterm source
+ADD . /srv/showterm
+
+# Set DB config & do DB init / seed
+RUN cp config/database.yml.example config/database.yml \
+  && bundle exec rake db:create db:migrate db:seed \
+  && mv /var/showterm/showterm.sqlite3 ./showterm.sqlite3
+
+EXPOSE 3000
+VOLUME ["/var/showterm"]
+ENTRYPOINT ["/srv/showterm/docker-entrypoint.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
 source 'https://rubygems.org'
-ruby '2.1.1'
+ruby '2.1.2'
 
 gem 'rails'
 gem 'heroku'
 gem 'bugsnag'
 gem 'secure_equals'
 gem 'rails_12factor'
+gem 'sqlite3'
 
 gem 'skylight'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.1.0)
       thread_safe (~> 0.1)
+    sqlite3 (1.3.9)
 
 PLATFORMS
   ruby

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,0 +1,5 @@
+development:
+  adapter: sqlite3
+  database: /var/showterm/showterm.sqlite3
+  pool: 5
+  timeout: 5000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# If DB doesn't already exist, copy pre-initialized db
+if [ -f /var/showterm/showterm.sqlite3 ];
+then
+  chown -R showterm /var/showterm
+else
+  mv /srv/showterm/showterm.sqlite3 /var/showterm/showterm.sqlite3
+  chown -R showterm /var/showterm
+fi
+
+
+# Start showterm
+exec su showterm -s /bin/bash -p -c "bin/rails server"


### PR DESCRIPTION
This commit adds a Docker build process to showterm. If merged, this will make showterm installation a two command process for Docker users. Also, if you opt to push this up onto the Docker registry, then downloading and running showterm will be a one command process.

Please let me know if you have any questons, or suggestions for improvement.